### PR TITLE
Query method change w/ benchmark tests

### DIFF
--- a/hrr50-front-end-capstone-master/database/database.test.js
+++ b/hrr50-front-end-capstone-master/database/database.test.js
@@ -1,0 +1,9 @@
+const {retrieveOneProperty} = require('./index.js');
+
+console.time('A');
+retrieveOneProperty(9000000, (err, results) => {
+  console.timeEnd('A');
+  if (err) {
+    console.log('ENDED WITH ERROR: ', err);
+  }
+});

--- a/hrr50-front-end-capstone-master/database/database.test.js
+++ b/hrr50-front-end-capstone-master/database/database.test.js
@@ -1,7 +1,7 @@
 const {retrieveOneProperty} = require('./index.js');
 
 console.time('A');
-retrieveOneProperty(9000000, (err, results) => {
+retrieveOneProperty(9999999, (err, results) => {
   console.timeEnd('A');
   if (err) {
     console.log('ENDED WITH ERROR: ', err);

--- a/hrr50-front-end-capstone-master/database/database.test.js
+++ b/hrr50-front-end-capstone-master/database/database.test.js
@@ -1,9 +1,0 @@
-const {retrieveOneProperty} = require('./index.js');
-
-console.time('A');
-retrieveOneProperty(9999999, (err, results) => {
-  console.timeEnd('A');
-  if (err) {
-    console.log('ENDED WITH ERROR: ', err);
-  }
-});

--- a/hrr50-front-end-capstone-master/database/index.js
+++ b/hrr50-front-end-capstone-master/database/index.js
@@ -8,13 +8,36 @@ const connectionString = `postgres://${PG_HOST}:${PG_PORT}/${PG_DB}`;
 const db = pgp(connectionString);
 
 const retrieveOneProperty = (id, cb) => {
-  const queryString = `SELECT name, city, region, country, ph.url, ph.caption, r.stars FROM properties pr INNER JOIN photos ph ON ph.propertyId = pr.id INNER JOIN reviews r ON r.propertyId = pr.id WHERE pr.id = ${id}`;
+  const queryString = `SELECT pr.id, name, city, region, country, ph.url, ph.caption, SUM(r.stars) AS stars, COUNT(r.stars) AS reviews FROM properties pr LEFT JOIN photos ph ON ph.propertyId = pr.id LEFT JOIN reviews r ON r.propertyId = pr.id WHERE pr.id = ${id} GROUP BY pr.id, ph.id`;
   db.query(queryString)
-    .then(data => cb(null, data))
+    .then(data => {
+      var {id, name, city, region, country, stars, reviews} = data[0];
+      var property = {id, name, city, region, country, stars, reviews};
+      property.photos = data.map(photo => {
+        return {
+          url: photo.url,
+          caption: photo.caption
+        };
+      });
+      cb(null, property);
+    })
+    .catch(err => cb(err));
+};
+
+const retrievePropertySplit = (id, cb) => {
+  const prop = `SELECT p.id, name, city, region, country, SUM(r.stars) AS stars, COUNT(r.stars) AS reviews FROM properties p LEFT JOIN reviews r ON r.propertyId = p.id WHERE p.id = ${id} GROUP BY p.id`;
+  const photos = `SELECT url, caption FROM photos WHERE propertyId = ${id}`;
+  Promise.all([db.one(prop), db.query(photos)])
+    .then(data => {
+      var property = data[0];
+      property.photos = data[1];
+      cb(null, property);
+    })
     .catch(err => cb(err));
 };
 
 module.exports = {
-  db: db,
-  retrieveOneProperty: retrieveOneProperty
+  db,
+  retrieveOneProperty,
+  retrievePropertySplit
 };

--- a/hrr50-front-end-capstone-master/database/index.js
+++ b/hrr50-front-end-capstone-master/database/index.js
@@ -8,7 +8,7 @@ const connectionString = `postgres://${PG_HOST}:${PG_PORT}/${PG_DB}`;
 const db = pgp(connectionString);
 
 const retrieveOneProperty = (id, cb) => {
-  const queryString = `SELECT name, city, region, country, ph.url, ph.caption FROM properties pr INNER JOIN photos ph ON ph.propertyId = pr.id WHERE pr.id = ${id}`;
+  const queryString = `SELECT name, city, region, country, ph.url, ph.caption, r.stars FROM properties pr INNER JOIN photos ph ON ph.propertyId = pr.id INNER JOIN reviews r ON r.propertyId = pr.id WHERE pr.id = ${id}`;
   db.query(queryString)
     .then(data => cb(null, data))
     .catch(err => cb(err));

--- a/hrr50-front-end-capstone-master/database/tests/groupedQuery.test.js
+++ b/hrr50-front-end-capstone-master/database/tests/groupedQuery.test.js
@@ -1,0 +1,9 @@
+const {retrieveOneProperty} = require('../index.js');
+
+console.time('all together');
+retrieveOneProperty(9999999, (err, results) => {
+  console.timeEnd('all together');
+  if (err) {
+    console.log('ENDED WITH ERROR: ', err);
+  }
+});

--- a/hrr50-front-end-capstone-master/database/tests/splitQuery.test.js
+++ b/hrr50-front-end-capstone-master/database/tests/splitQuery.test.js
@@ -1,0 +1,9 @@
+const {retrievePropertySplit} = require('../index.js');
+
+console.time('split query');
+retrievePropertySplit(9999999, (err, results) => {
+  console.timeEnd('split query');
+  if (err) {
+    console.log('ENDED WITH ERROR: ', err);
+  }
+});

--- a/hrr50-front-end-capstone-master/package.json
+++ b/hrr50-front-end-capstone-master/package.json
@@ -13,7 +13,8 @@
     "makeSeeds": "node database/createSeeds.js",
     "seed": "node database/seed.js",
     "test": "mocha --recursive --exit",
-    "test-db": "node database/database.test.js"
+    "test-db-group": "node database/tests/groupedQuery.test.js",
+    "test-db-split": "node database/tests/splitQuery.test.js"
   },
   "dependencies": {
     "@babel/cli": "^7.12.10",

--- a/hrr50-front-end-capstone-master/package.json
+++ b/hrr50-front-end-capstone-master/package.json
@@ -12,7 +12,8 @@
     "build-dev": "webpack -w",
     "makeSeeds": "node database/createSeeds.js",
     "seed": "node database/seed.js",
-    "test": "mocha --recursive --exit"
+    "test": "mocha --recursive --exit",
+    "test-db": "node database/database.test.js"
   },
   "dependencies": {
     "@babel/cli": "^7.12.10",

--- a/hrr50-front-end-capstone-master/schema.sql
+++ b/hrr50-front-end-capstone-master/schema.sql
@@ -23,3 +23,6 @@ CREATE TABLE reviews (
   propertyId INT REFERENCES properties (id),
   stars INT NOT NULL
 );
+
+CREATE INDEX ON photos (propertyId);
+CREATE INDEX ON reviews (propertyId);

--- a/hrr50-front-end-capstone-master/server/server.js
+++ b/hrr50-front-end-capstone-master/server/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const path = require('path');
 const compression = require('compression');
-const { retrieveOneProperty, retrievePropertySplit } = require('../database/index.js');
+const { retrievePropertySplit } = require('../database/index.js');
 
 const port = process.env.PORT || 3000;
 const app = express();
@@ -11,16 +11,6 @@ app.use('/', express.static(path.join(__dirname, '..', 'public')));
 app.use('/bundle', express.static(path.join(__dirname, '..', 'public/app.js')));
 
 app.get('/photos', (req, res) => {
-  var property = req.query.property || 1;
-  retrieveOneProperty(property, (err, results) => {
-    if (err) {
-      res.send(err);
-    } else {
-      res.send(results);
-    }
-  });
-});
-app.get('/photos2', (req, res) => {
   var property = req.query.property || 1;
   retrievePropertySplit(property, (err, results) => {
     if (err) {

--- a/hrr50-front-end-capstone-master/server/server.js
+++ b/hrr50-front-end-capstone-master/server/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const path = require('path');
 const compression = require('compression');
-const { retrieveOneProperty } = require('../database/index.js');
+const { retrieveOneProperty, retrievePropertySplit } = require('../database/index.js');
 
 const port = process.env.PORT || 3000;
 const app = express();
@@ -13,6 +13,16 @@ app.use('/bundle', express.static(path.join(__dirname, '..', 'public/app.js')));
 app.get('/photos', (req, res) => {
   var property = req.query.property || 1;
   retrieveOneProperty(property, (err, results) => {
+    if (err) {
+      res.send(err);
+    } else {
+      res.send(results);
+    }
+  });
+});
+app.get('/photos2', (req, res) => {
+  var property = req.query.property || 1;
+  retrievePropertySplit(property, (err, results) => {
     if (err) {
       res.send(err);
     } else {


### PR DESCRIPTION
In this pull request, I've created a new method for querying the DB for the data required by the API. Specifically, I now run two parallel queries, one for a _single_ property and its associated review count, the other for the list of photos associated to that property. Benchmark tests (added in this PR) for this Split Query method show a performance gain of 2 ms over the previous method of performing a single query against the property table, joined with reviews and photos. As such the server route has been changed to use the new Split Query method. I am keeping the Grouped Query method around for now as it may be better for deployment if I use a cloud db service that has a cost per individual query.